### PR TITLE
Update es_mx.json

### DIFF
--- a/src/main/resources/assets/woodworks/lang/es_mx.json
+++ b/src/main/resources/assets/woodworks/lang/es_mx.json
@@ -71,7 +71,7 @@
     "block.woodworks.spruce_ladder": "Escaleras de abeto",
     "block.woodworks.spruce_leaf_pile": "Montón de hojas de abeto",
     "block.woodworks.trapped_acacia_chest": "Cofre trampa de acacia",
-    "block.woodworks.trapped_bamboo_closet": "Cofre trampa de bambú",
+    "block.woodworks.trapped_bamboo_closet": "Armario trampa de bambú",
     "block.woodworks.trapped_birch_chest": "Cofre trampa de abedul",
     "block.woodworks.trapped_cherry_chest": "Cofre trampa de cerezo",
     "block.woodworks.trapped_crimson_chest": "Cofre trampa carmesí",


### PR DESCRIPTION
- fixed an inconsistency with the trapped bamboo closet, being translated as "Cofre trampa de bambú" instead of "Armario trampa de bambú"