### PR TITLE
Add vanilla chest recipe

### DIFF
--- a/src/generated/resources/data/woodworks/advancement/recipes/decorations/chest_from_modded_chest.json
+++ b/src/generated/resources/data/woodworks/advancement/recipes/decorations/chest_from_modded_chest.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "woodworks:chest_from_modded_chest"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    },
+    "has_woodworks_chest": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#woodworks:woodworks_chests"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_woodworks_chest"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "woodworks:chest_from_modded_chest"
+    ]
+  }
+}

--- a/src/generated/resources/data/woodworks/recipe/chest_from_modded_chest.json
+++ b/src/generated/resources/data/woodworks/recipe/chest_from_modded_chest.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "tag": "woodworks:woodworks_chests"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:chest"
+  }
+}

--- a/src/generated/resources/data/woodworks/tags/item/woodworks_chests.json
+++ b/src/generated/resources/data/woodworks/tags/item/woodworks_chests.json
@@ -1,0 +1,15 @@
+{
+  "values": [
+    "woodworks:oak_chest",
+    "woodworks:spruce_chest",
+    "woodworks:birch_chest",
+    "woodworks:jungle_chest",
+    "woodworks:acacia_chest",
+    "woodworks:dark_oak_chest",
+    "woodworks:mangrove_chest",
+    "woodworks:cherry_chest",
+    "woodworks:bamboo_closet",
+    "woodworks:crimson_chest",
+    "woodworks:warped_chest"
+  ]
+}

--- a/src/main/java/com/teamabnormals/woodworks/core/data/server/WoodworksRecipeProvider.java
+++ b/src/main/java/com/teamabnormals/woodworks/core/data/server/WoodworksRecipeProvider.java
@@ -4,6 +4,8 @@ import com.teamabnormals.blueprint.core.api.conditions.BlueprintAndCondition;
 import com.teamabnormals.blueprint.core.data.server.BlueprintRecipeProvider;
 import com.teamabnormals.woodworks.common.item.crafting.SawmillRecipe;
 import com.teamabnormals.woodworks.core.Woodworks;
+import com.teamabnormals.woodworks.core.data.server.tags.WoodworksItemTagsProvider;
+
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.advancements.critereon.InventoryChangeTrigger;
 import net.minecraft.advancements.critereon.MinMaxBounds;
@@ -48,6 +50,12 @@ public class WoodworksRecipeProvider extends BlueprintRecipeProvider implements 
 		ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, Blocks.BEEHIVE).define('P', ItemTags.PLANKS).define('H', Items.HONEYCOMB).pattern("PPP").pattern("HHH").pattern("PPP").unlockedBy("has_honeycomb", has(Items.HONEYCOMB)).save(output.withConditions(config(COMMON.woodenBeehives, "wooden_beehives", true)));
 		ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, Blocks.CHEST).define('#', ItemTags.PLANKS).pattern("###").pattern("# #").pattern("###").unlockedBy("has_lots_of_items", CriteriaTriggers.INVENTORY_CHANGED.createCriterion(new InventoryChangeTrigger.TriggerInstance(Optional.empty(), new InventoryChangeTrigger.TriggerInstance.Slots(MinMaxBounds.Ints.atLeast(10), MinMaxBounds.Ints.ANY, MinMaxBounds.Ints.ANY), List.of()))).save(output.withConditions(config(COMMON.woodenChests, "wooden_chests", true)));
 
+		/* Allow crafting vanilla chests from Woodworks chests */
+		ShapelessRecipeBuilder.shapeless(RecipeCategory.DECORATIONS, Blocks.CHEST)
+			.requires(WoodworksItemTagsProvider.WOODWORKS_CHESTS)
+			.unlockedBy("has_woodworks_chest", has(WoodworksItemTagsProvider.WOODWORKS_CHESTS))
+			.save(output, ResourceLocation.fromNamespaceAndPath(Woodworks.MOD_ID, "chest_from_modded_chest"));
+		
 		ShapelessRecipeBuilder.shapeless(RecipeCategory.REDSTONE, Blocks.TRAPPED_CHEST).requires(Tags.Items.CHESTS_WOODEN).requires(Blocks.TRIPWIRE_HOOK).unlockedBy("has_tripwire_hook", has(Blocks.TRIPWIRE_HOOK)).save(output.withConditions(config(COMMON.woodenChests, "wooden_chests", true)));
 		ShapelessRecipeBuilder.shapeless(RecipeCategory.REDSTONE, Blocks.TRAPPED_CHEST).requires(Blocks.CHEST).requires(Blocks.TRIPWIRE_HOOK).unlockedBy("has_tripwire_hook", has(Blocks.TRIPWIRE_HOOK)).save(output.withConditions(WOODEN_CHESTS), Woodworks.location("trapped_chest"));
 		ShapedRecipeBuilder.shaped(RecipeCategory.REDSTONE, Blocks.LECTERN).define('S', ItemTags.WOODEN_SLABS).define('B', Tags.Items.BOOKSHELVES).pattern("SSS").pattern(" B ").pattern(" S ").unlockedBy("has_book", has(Items.BOOK)).save(output);

--- a/src/main/java/com/teamabnormals/woodworks/core/data/server/tags/WoodworksItemTagsProvider.java
+++ b/src/main/java/com/teamabnormals/woodworks/core/data/server/tags/WoodworksItemTagsProvider.java
@@ -4,10 +4,14 @@ import com.teamabnormals.blueprint.core.data.server.tags.BlueprintItemTagsProvid
 import com.teamabnormals.blueprint.core.other.tags.BlueprintBlockTags;
 import com.teamabnormals.woodworks.core.Woodworks;
 import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
@@ -22,11 +26,29 @@ public class WoodworksItemTagsProvider extends BlueprintItemTagsProvider {
 		super(Woodworks.MOD_ID, output, provider, tagLookup, helper);
 	}
 
+	public static final TagKey<Item> WOODWORKS_CHESTS = TagKey.create(BuiltInRegistries.ITEM.key(), ResourceLocation.fromNamespaceAndPath(Woodworks.MOD_ID, "woodworks_chests"));
+
 	@Override
 	protected void addTags(Provider provider) {
 		this.copyWoodworksTags();
 		this.copy(BlueprintBlockTags.LEAF_PILES, LEAF_PILES);
 		this.copy(BlockTags.FLOWERS, ItemTags.FLOWERS);
 		this.tag(ItemTags.NON_FLAMMABLE_WOOD).add(CRIMSON_BOARDS.get().asItem(), WARPED_BOARDS.get().asItem(), CRIMSON_BOOKSHELF.get().asItem(), WARPED_BOOKSHELF.get().asItem(), CHISELED_CRIMSON_BOOKSHELF.get().asItem(), CHISELED_WARPED_BOOKSHELF.get().asItem(), CRIMSON_LADDER.get().asItem(), WARPED_LADDER.get().asItem(), CRIMSON_BEEHIVE.get().asItem(), WARPED_BEEHIVE.get().asItem(), CRIMSON_CHEST.get().asItem(), WARPED_CHEST.get().asItem(), TRAPPED_CRIMSON_CHEST.get().asItem(), TRAPPED_WARPED_CHEST.get().asItem());
+	
+		/* All chests specifically added by Woodworks */
+		this.tag(WOODWORKS_CHESTS)
+			.add(
+				OAK_CHEST.asItem(),
+				SPRUCE_CHEST.asItem(),
+				BIRCH_CHEST.asItem(),
+				JUNGLE_CHEST.asItem(),
+				ACACIA_CHEST.asItem(),
+				DARK_OAK_CHEST.asItem(),
+				MANGROVE_CHEST.asItem(),
+				CHERRY_CHEST.asItem(),
+				BAMBOO_CLOSET.asItem(),
+				CRIMSON_CHEST.asItem(),
+				WARPED_CHEST.asItem()
+			);
 	}
 }


### PR DESCRIPTION
This PR adds a shapeless vanilla chest recipe from any of the Woodworks chests, in case you prefer the vanilla look, and for compatibility reasons.

<img width="316" height="166" alt="2025-08-30-04-52-43" src="https://github.com/user-attachments/assets/69b4ec5c-adc9-4de7-9782-4a497670daa2" />
<img width="544" height="289" alt="2025-08-30-04-53-00" src="https://github.com/user-attachments/assets/12510ae4-2a54-46d2-91a1-6d12dfb6dd6b" />
